### PR TITLE
Add batching feature to bulk send log events

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,6 +11,10 @@ jobs:
   test_lint:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        node-version: [14,16,18]
+
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,6 +25,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
 
-      - run: npm install
-      - run: npm run build --noEmit
-      - run: npm run test
+      - run: yarn install
+      - run: yarn run build --noEmit
+      - run: yarn run test

--- a/README.md
+++ b/README.md
@@ -27,3 +27,10 @@ const logger = createLogger({
 ## Options
 * __licenseKey__: New Relic license key.
 * __apiUrl__: New Relic Log Base API URL.
+* __axiosOptions__: Options passed to Axios when sending data. (Optional)
+* __batchSize__:  How many log items you would like to bundle together before posting to loggly. (Optional, positive integer or true, default 100)
+* __batchThrottle__: The maximum frequency the batch posting should occur unless the batch size is exceeded. (Optional, positive integer or true, default 1000)
+
+### Batching
+
+If either batching option is set without the other, or simply set as `true` then default values are used as specified. 

--- a/index.integration.test.ts
+++ b/index.integration.test.ts
@@ -1,0 +1,68 @@
+import WinstonNewrelicLogsTransport from "index";
+import { expect, test, vi } from "vitest";
+import { LEVEL, MESSAGE } from "triple-beam";
+
+/**
+ * READ ME!!
+ * 
+ * This is a simple integration tests but it requires a NewRelic account and manual validation
+ * to check. If you want to run these tests you must
+ * 
+ * 1. Uncomment the marked line from vitest.config.ts
+ * 2. Run with the command `KEY=YOUR_KEY yarn test integration`
+ * 
+ * It will write 51 log entries to NewRelic, make sure they're there. 
+ */
+
+const licenseKey = process.env.KEY;
+
+const errorEventHandler = vi.fn();
+const loggedEventHandler = vi.fn();
+const cb = vi.fn();
+
+test("should send data single", async () => {
+  const transport = new WinstonNewrelicLogsTransport({
+    apiUrl: "https://log-api.newrelic.com",
+    licenseKey,
+  });
+  transport.on('error', errorEventHandler);
+  transport.on('logged', loggedEventHandler);
+
+  transport.log({
+    [LEVEL]: "info",
+    [MESSAGE]: "test integration single",
+  }, cb);
+
+  await new Promise((resolve) => {
+    setTimeout(resolve, 5000);
+  })
+
+  expect(cb).toHaveBeenCalledWith(null);
+  expect(errorEventHandler).not.toHaveBeenCalled();
+  expect(loggedEventHandler).toHaveBeenCalledTimes(1);
+});
+
+test("should send data batch", async () => {
+  const transport = new WinstonNewrelicLogsTransport({
+    apiUrl: "https://log-api.newrelic.com",
+    licenseKey,
+    batchThrottle: 1000
+  });
+  transport.on('error', errorEventHandler);
+  transport.on('logged', loggedEventHandler);
+
+  for (let i = 0; i < 50; i++) {
+    transport.log({
+      [LEVEL]: "info",
+      [MESSAGE]: `test integration ${i + 1}`,
+    }, cb);
+  }
+
+  await new Promise((resolve) => {
+    setTimeout(resolve, 5000);
+  })
+
+  expect(cb).toHaveBeenCalledWith(null);
+  expect(errorEventHandler).not.toHaveBeenCalled();
+  expect(loggedEventHandler).toHaveBeenCalledTimes(50);
+});

--- a/index.test.ts
+++ b/index.test.ts
@@ -66,12 +66,13 @@ describe("single mode", () => {
 
     expect(mockPost).toHaveBeenCalledTimes(1);
     expect(mockPost).toHaveBeenCalledWith("/log/v1", {
-      logtype: "info",
-      message: "Some message",
-      timestamp: expect.any(Number),
+      timestamp: expect.any(String),
+      [MESSAGE]: "Some message",
+      [LEVEL]: "info",
     });
 
     await vi.runAllTimersAsync();
+
     expect(cb).toHaveBeenCalledWith(null);
   });
 
@@ -92,6 +93,7 @@ describe("single mode", () => {
     transport.log({ [MESSAGE]: "Some message", [LEVEL]: "info" }, cb);
 
     await vi.advanceTimersByTimeAsync(100);
+
     expect(cb).toHaveBeenCalledWith(err);
     expect(errorEventHandler).toHaveBeenCalledWith(err);
   });
@@ -154,6 +156,7 @@ describe("batch mode", () => {
     expect(mockPost).not.toHaveBeenCalledTimes(1);
 
     await vi.advanceTimersByTimeAsync(500);
+
     expect(cb).toHaveBeenCalledWith(null);
 
     await vi.advanceTimersByTimeAsync(1000);
@@ -163,31 +166,31 @@ describe("batch mode", () => {
       {
         logs: [
           {
-            logtype: "info",
-            message: "Some message 1",
-            timestamp: expect.any(Number),
+            timestamp: expect.any(String),
+            [MESSAGE]: "Some message 1",
+            [LEVEL]: "info",
           },
           {
-            logtype: "info",
-            message: "Some message 2",
-            timestamp: expect.any(Number),
+            timestamp: expect.any(String),
+            [MESSAGE]: "Some message 2",
+            [LEVEL]: "info",
           },
           {
-            logtype: "info",
-            message: "Some message 3",
-            timestamp: expect.any(Number),
+            timestamp: expect.any(String),
+            [MESSAGE]: "Some message 3",
+            [LEVEL]: "info",
           },
           {
-            logtype: "info",
-            message: "Some message 4",
-            timestamp: expect.any(Number),
+            timestamp: expect.any(String),
+            [MESSAGE]: "Some message 4",
+            [LEVEL]: "info",
           },
         ],
       },
     ]);
   });
 
-  test("should batch send immediately if the size limit is breached ", async () => {
+  test("should batch send immediately if the size limit is breached", async () => {
     const transport = new WinstonNewrelicLogsTransport({
       apiUrl: "logs.foo.com",
       licenseKey: "000000",
@@ -210,25 +213,26 @@ describe("batch mode", () => {
       {
         logs: [
           {
-            logtype: "info",
-            message: "Some message 1",
-            timestamp: expect.any(Number),
+            timestamp: expect.any(String),
+            [MESSAGE]: "Some message 1",
+            [LEVEL]: "info",
           },
           {
-            logtype: "info",
-            message: "Some message 2",
-            timestamp: expect.any(Number),
+            timestamp: expect.any(String),
+            [MESSAGE]: "Some message 2",
+            [LEVEL]: "info",
           },
           {
-            logtype: "info",
-            message: "Some message 3",
-            timestamp: expect.any(Number),
+            timestamp: expect.any(String),
+            [MESSAGE]: "Some message 3",
+            [LEVEL]: "info",
           },
         ],
       },
     ]);
 
     await vi.advanceTimersByTimeAsync(500);
+
     expect(cb).toHaveBeenCalledWith(null);
 
     await vi.advanceTimersByTimeAsync(1000);
@@ -239,14 +243,14 @@ describe("batch mode", () => {
       {
         logs: [
           {
-            logtype: "info",
-            message: "Some message 4",
-            timestamp: expect.any(Number),
+            timestamp: expect.any(String),
+            [MESSAGE]: "Some message 4",
+            [LEVEL]: "info",
           },
           {
-            logtype: "info",
-            message: "Some message 5",
-            timestamp: expect.any(Number),
+            timestamp: expect.any(String),
+            [MESSAGE]: "Some message 5",
+            [LEVEL]: "info",
           },
         ],
       },

--- a/index.test.ts
+++ b/index.test.ts
@@ -66,7 +66,7 @@ describe("single mode", () => {
 
     expect(mockPost).toHaveBeenCalledTimes(1);
     expect(mockPost).toHaveBeenCalledWith("/log/v1", {
-      timestamp: expect.any(String),
+      timestamp: expect.any(Number),
       [MESSAGE]: "Some message",
       [LEVEL]: "info",
     });
@@ -166,22 +166,22 @@ describe("batch mode", () => {
       {
         logs: [
           {
-            timestamp: expect.any(String),
+            timestamp: expect.any(Number),
             [MESSAGE]: "Some message 1",
             [LEVEL]: "info",
           },
           {
-            timestamp: expect.any(String),
+            timestamp: expect.any(Number),
             [MESSAGE]: "Some message 2",
             [LEVEL]: "info",
           },
           {
-            timestamp: expect.any(String),
+            timestamp: expect.any(Number),
             [MESSAGE]: "Some message 3",
             [LEVEL]: "info",
           },
           {
-            timestamp: expect.any(String),
+            timestamp: expect.any(Number),
             [MESSAGE]: "Some message 4",
             [LEVEL]: "info",
           },
@@ -213,17 +213,17 @@ describe("batch mode", () => {
       {
         logs: [
           {
-            timestamp: expect.any(String),
+            timestamp: expect.any(Number),
             [MESSAGE]: "Some message 1",
             [LEVEL]: "info",
           },
           {
-            timestamp: expect.any(String),
+            timestamp: expect.any(Number),
             [MESSAGE]: "Some message 2",
             [LEVEL]: "info",
           },
           {
-            timestamp: expect.any(String),
+            timestamp: expect.any(Number),
             [MESSAGE]: "Some message 3",
             [LEVEL]: "info",
           },
@@ -243,12 +243,12 @@ describe("batch mode", () => {
       {
         logs: [
           {
-            timestamp: expect.any(String),
+            timestamp: expect.any(Number),
             [MESSAGE]: "Some message 4",
             [LEVEL]: "info",
           },
           {
-            timestamp: expect.any(String),
+            timestamp: expect.any(Number),
             [MESSAGE]: "Some message 5",
             [LEVEL]: "info",
           },

--- a/index.test.ts
+++ b/index.test.ts
@@ -1,5 +1,8 @@
-import WinstonNewrelicLogsTransport from "index";
-import { beforeAll, expect, test, vi } from "vitest";
+import WinstonNewrelicLogsTransport, {
+  defaultBatchSize,
+  defaultBatchThrottle,
+} from "index";
+import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { LEVEL, MESSAGE } from "triple-beam";
 import axios, { AxiosInstance } from "axios";
 
@@ -12,7 +15,7 @@ const mockAxiosClient = {
   post: mockPost,
 } as Partial<AxiosInstance> as AxiosInstance;
 
-beforeAll(() => {
+beforeEach(() => {
   axiosCreateSpy.mockReturnValue(mockAxiosClient);
 
   mockPost.mockImplementation(
@@ -23,10 +26,12 @@ beforeAll(() => {
         });
       })
   );
+
+  vi.clearAllTimers();
 });
 
-test("should post and fire callback", async () => {
-  const transport = new WinstonNewrelicLogsTransport({
+test("should setup axios", async () => {
+  new WinstonNewrelicLogsTransport({
     apiUrl: "logs.foo.com",
     licenseKey: "000000",
     axiosOptions: {
@@ -39,36 +44,199 @@ test("should post and fire callback", async () => {
     baseURL: "logs.foo.com",
     headers: {
       "Content-Type": "application/json",
-      "X-License-Key": "000000",
+      "Api-Key": "000000",
     },
     timeout: 123456,
   });
-
-  const cb = vi.fn();
-
-  transport.log({ [MESSAGE]: "Some message", [LEVEL]: "info" }, cb);
-
-  await vi.runAllTimersAsync();
-  expect(cb).toHaveBeenCalledWith(null);
 });
 
-test("should handle errors", async () => {
-  const errorEventHandler = vi.fn();
+describe("single mode", () => {
+  test("should post and fire callback", async () => {
+    const transport = new WinstonNewrelicLogsTransport({
+      apiUrl: "logs.foo.com",
+      licenseKey: "000000",
+      axiosOptions: {
+        timeout: 123456,
+      },
+    });
 
-  const transport = new WinstonNewrelicLogsTransport({
-    apiUrl: "logs.foo.com",
-    licenseKey: "000000",
+    const cb = vi.fn();
+
+    transport.log({ [MESSAGE]: "Some message", [LEVEL]: "info" }, cb);
+
+    expect(mockPost).toHaveBeenCalledTimes(1);
+    expect(mockPost).toHaveBeenCalledWith("/log/v1", {
+      logtype: "info",
+      message: "Some message",
+      timestamp: expect.any(Number),
+    });
+
+    await vi.runAllTimersAsync();
+    expect(cb).toHaveBeenCalledWith(null);
   });
-  transport.on("error", errorEventHandler);
 
-  const cb = vi.fn();
+  test("should handle errors", async () => {
+    const errorEventHandler = vi.fn();
 
-  const err = new Error("A timeout or something");
-  mockPost.mockRejectedValue(err);
+    const transport = new WinstonNewrelicLogsTransport({
+      apiUrl: "logs.foo.com",
+      licenseKey: "000000",
+    });
+    transport.on("error", errorEventHandler);
 
-  transport.log({ [MESSAGE]: "Some message", [LEVEL]: "info" }, cb);
+    const cb = vi.fn();
 
-  await vi.runAllTimersAsync();
-  expect(cb).toHaveBeenCalledWith(err);
-  expect(errorEventHandler).toHaveBeenCalledWith(err);
+    const err = new Error("A timeout or something");
+    mockPost.mockRejectedValue(err);
+
+    transport.log({ [MESSAGE]: "Some message", [LEVEL]: "info" }, cb);
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(cb).toHaveBeenCalledWith(err);
+    expect(errorEventHandler).toHaveBeenCalledWith(err);
+  });
+});
+
+describe("batch mode", () => {
+  test("should throw with bad batch size", () => {
+    expect(
+      () =>
+        new WinstonNewrelicLogsTransport({
+          apiUrl: "logs.foo.com",
+          licenseKey: "000000",
+          batchSize: -1,
+        })
+    ).toThrowErrorMatchingInlineSnapshot(
+      '"Expected a batchSize greater than 0"'
+    );
+  });
+
+  test("should throw with bad throttle", () => {
+    expect(
+      () =>
+        new WinstonNewrelicLogsTransport({
+          apiUrl: "logs.foo.com",
+          licenseKey: "000000",
+          batchThrottle: -4000,
+        })
+    ).toThrowErrorMatchingInlineSnapshot(
+      '"Expected a batchThrottle greater than 0"'
+    );
+  });
+
+  test("should setup defaults", () => {
+    const transport = new WinstonNewrelicLogsTransport({
+      apiUrl: "logs.foo.com",
+      licenseKey: "000000",
+      batchThrottle: true,
+    });
+
+    expect(transport.batchSize).toEqual(defaultBatchSize);
+    expect(transport.batchThrottle).toEqual(defaultBatchThrottle);
+  });
+
+  test("should batch send", async () => {
+    const transport = new WinstonNewrelicLogsTransport({
+      apiUrl: "logs.foo.com",
+      licenseKey: "000000",
+      batchThrottle: true,
+    });
+
+    const cb = vi.fn();
+
+    for (let i = 0; i < 4; i++) {
+      transport.log({ [MESSAGE]: `Some message ${i + 1}`, [LEVEL]: "info" }, cb);
+    }
+
+    expect(mockPost).not.toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(cb).toHaveBeenCalledWith(null);
+
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(mockPost).toHaveBeenCalledTimes(1);
+    expect(mockPost).toHaveBeenCalledWith("/log/v1", {
+      logs: [
+        {
+          logtype: "info",
+          message: "Some message 1",
+          timestamp: expect.any(Number),
+        },
+        {
+          logtype: "info",
+          message: "Some message 2",
+          timestamp: expect.any(Number),
+        },
+        {
+          logtype: "info",
+          message: "Some message 3",
+          timestamp: expect.any(Number),
+        },
+        {
+          logtype: "info",
+          message: "Some message 4",
+          timestamp: expect.any(Number),
+        },
+      ],
+    });
+  });
+
+  test("should batch send immediately if the size limit is breached ", async () => {
+    const transport = new WinstonNewrelicLogsTransport({
+      apiUrl: "logs.foo.com",
+      licenseKey: "000000",
+      batchThrottle: true,
+      batchSize: 3
+    });
+
+    const cb = vi.fn();
+
+    for (let i = 0; i < 5; i++) {
+      transport.log({ [MESSAGE]: `Some message ${i + 1}`, [LEVEL]: "info" }, cb);
+    }
+
+    expect(mockPost).toHaveBeenCalledTimes(1);
+    expect(mockPost.mock.calls[0][1].logs).toHaveLength(3);
+    expect(mockPost).toHaveBeenCalledWith("/log/v1", {
+      logs: [
+        {
+          logtype: "info",
+          message: "Some message 1",
+          timestamp: expect.any(Number),
+        },
+        {
+          logtype: "info",
+          message: "Some message 2",
+          timestamp: expect.any(Number),
+        },
+        {
+          logtype: "info",
+          message: "Some message 3",
+          timestamp: expect.any(Number),
+        },
+      ],
+    });
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(cb).toHaveBeenCalledWith(null);
+
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(mockPost).toHaveBeenCalledTimes(2);
+    expect(mockPost).toHaveBeenCalledWith("/log/v1", {
+      logs: [
+        {
+          logtype: "info",
+          message: "Some message 4",
+          timestamp: expect.any(Number),
+        },
+        {
+          logtype: "info",
+          message: "Some message 5",
+          timestamp: expect.any(Number),
+        },
+      ],
+    });
+  });
 });

--- a/index.test.ts
+++ b/index.test.ts
@@ -159,30 +159,32 @@ describe("batch mode", () => {
     await vi.advanceTimersByTimeAsync(1000);
 
     expect(mockPost).toHaveBeenCalledTimes(1);
-    expect(mockPost).toHaveBeenCalledWith("/log/v1", {
-      logs: [
-        {
-          logtype: "info",
-          message: "Some message 1",
-          timestamp: expect.any(Number),
-        },
-        {
-          logtype: "info",
-          message: "Some message 2",
-          timestamp: expect.any(Number),
-        },
-        {
-          logtype: "info",
-          message: "Some message 3",
-          timestamp: expect.any(Number),
-        },
-        {
-          logtype: "info",
-          message: "Some message 4",
-          timestamp: expect.any(Number),
-        },
-      ],
-    });
+    expect(mockPost).toHaveBeenCalledWith("/log/v1", [
+      {
+        logs: [
+          {
+            logtype: "info",
+            message: "Some message 1",
+            timestamp: expect.any(Number),
+          },
+          {
+            logtype: "info",
+            message: "Some message 2",
+            timestamp: expect.any(Number),
+          },
+          {
+            logtype: "info",
+            message: "Some message 3",
+            timestamp: expect.any(Number),
+          },
+          {
+            logtype: "info",
+            message: "Some message 4",
+            timestamp: expect.any(Number),
+          },
+        ],
+      },
+    ]);
   });
 
   test("should batch send immediately if the size limit is breached ", async () => {
@@ -203,26 +205,28 @@ describe("batch mode", () => {
     }
 
     expect(mockPost).toHaveBeenCalledTimes(1);
-    expect(mockPost.mock.calls[0][1].logs).toHaveLength(3);
-    expect(mockPost).toHaveBeenCalledWith("/log/v1", {
-      logs: [
-        {
-          logtype: "info",
-          message: "Some message 1",
-          timestamp: expect.any(Number),
-        },
-        {
-          logtype: "info",
-          message: "Some message 2",
-          timestamp: expect.any(Number),
-        },
-        {
-          logtype: "info",
-          message: "Some message 3",
-          timestamp: expect.any(Number),
-        },
-      ],
-    });
+    expect(mockPost.mock.calls[0][1][0].logs).toHaveLength(3);
+    expect(mockPost).toHaveBeenCalledWith("/log/v1", [
+      {
+        logs: [
+          {
+            logtype: "info",
+            message: "Some message 1",
+            timestamp: expect.any(Number),
+          },
+          {
+            logtype: "info",
+            message: "Some message 2",
+            timestamp: expect.any(Number),
+          },
+          {
+            logtype: "info",
+            message: "Some message 3",
+            timestamp: expect.any(Number),
+          },
+        ],
+      },
+    ]);
 
     await vi.advanceTimersByTimeAsync(500);
     expect(cb).toHaveBeenCalledWith(null);
@@ -230,19 +234,22 @@ describe("batch mode", () => {
     await vi.advanceTimersByTimeAsync(1000);
 
     expect(mockPost).toHaveBeenCalledTimes(2);
-    expect(mockPost).toHaveBeenCalledWith("/log/v1", {
-      logs: [
-        {
-          logtype: "info",
-          message: "Some message 4",
-          timestamp: expect.any(Number),
-        },
-        {
-          logtype: "info",
-          message: "Some message 5",
-          timestamp: expect.any(Number),
-        },
-      ],
-    });
+    expect(mockPost.mock.calls[1][1][0].logs).toHaveLength(2);
+    expect(mockPost).toHaveBeenCalledWith("/log/v1", [
+      {
+        logs: [
+          {
+            logtype: "info",
+            message: "Some message 4",
+            timestamp: expect.any(Number),
+          },
+          {
+            logtype: "info",
+            message: "Some message 5",
+            timestamp: expect.any(Number),
+          },
+        ],
+      },
+    ]);
   });
 });

--- a/index.test.ts
+++ b/index.test.ts
@@ -2,7 +2,7 @@ import WinstonNewrelicLogsTransport, {
   defaultBatchSize,
   defaultBatchThrottle,
 } from "index";
-import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { LEVEL, MESSAGE } from "triple-beam";
 import axios, { AxiosInstance } from "axios";
 
@@ -145,7 +145,10 @@ describe("batch mode", () => {
     const cb = vi.fn();
 
     for (let i = 0; i < 4; i++) {
-      transport.log({ [MESSAGE]: `Some message ${i + 1}`, [LEVEL]: "info" }, cb);
+      transport.log(
+        { [MESSAGE]: `Some message ${i + 1}`, [LEVEL]: "info" },
+        cb
+      );
     }
 
     expect(mockPost).not.toHaveBeenCalledTimes(1);
@@ -187,13 +190,16 @@ describe("batch mode", () => {
       apiUrl: "logs.foo.com",
       licenseKey: "000000",
       batchThrottle: true,
-      batchSize: 3
+      batchSize: 3,
     });
 
     const cb = vi.fn();
 
     for (let i = 0; i < 5; i++) {
-      transport.log({ [MESSAGE]: `Some message ${i + 1}`, [LEVEL]: "info" }, cb);
+      transport.log(
+        { [MESSAGE]: `Some message ${i + 1}`, [LEVEL]: "info" },
+        cb
+      );
     }
 
     expect(mockPost).toHaveBeenCalledTimes(1);

--- a/index.ts
+++ b/index.ts
@@ -97,15 +97,19 @@ export default class WinstonNewrelicLogsTransport extends TransportStream {
 
   private batchPost() {
     try {
-      const toSend = this.logs.slice();
+      const logs = this.logs.slice();
       this.logs = [];
 
+      const data = [
+        {
+          logs,
+        },
+      ];
+
       this.axiosClient
-        .post("/log/v1", {
-          logs: toSend,
-        })
+        .post("/log/v1", data)
         .then(() => {
-          for (const log of toSend) {
+          for (const log of logs) {
             this.emit("logged", log);
           }
         })

--- a/index.ts
+++ b/index.ts
@@ -1,57 +1,158 @@
 import axios, { AxiosInstance, AxiosRequestConfig } from "axios";
 import TransportStream from "winston-transport";
 import { LEVEL, MESSAGE } from "triple-beam";
+import throttle from "lodash.throttle";
 
 export interface WinstonNewrelicLogsTransportOptions {
+  /**
+   * Your NewRelic key.
+   *
+   * @see https://docs.newrelic.com/docs/logs/log-api/introduction-log-api/#auth-header.
+   */
   licenseKey: string;
+  /**
+   * The URL to send data to.
+   *
+   * @see https://docs.newrelic.com/docs/logs/log-api/introduction-log-api/#endpoint.
+   */
   apiUrl: string;
+  /**
+   * Options to use when sending data via Axios.
+   */
   axiosOptions?: AxiosRequestConfig;
+  /**
+   * How many log items you would like to bundle together before posting to loggly.
+   */
+  batchSize?: number | true;
+  /**
+   * The maximum frequency the batch posting should occur unless the batch size is exceeded.
+   */
+  batchThrottle?: number | true;
 }
+
+interface LogEntry {
+  timestamp: number;
+  message: string;
+  logtype: string;
+}
+
+export const defaultBatchSize = 100;
+export const defaultBatchThrottle = 1000;
 
 /**
  * Transport for reporting errors to newrelic.
- * 
+ *
  * @type {WinstonNewrelicLogsTransport}
  * @extends {TransportStream}
  */
 export default class WinstonNewrelicLogsTransport extends TransportStream {
-  axiosClient: AxiosInstance;
+  private axiosClient: AxiosInstance;
+  private logs: LogEntry[];
+  public readonly batchSize?: number;
+  public readonly batchThrottle?: number;
+  private readonly throttledBatchPost: ReturnType<typeof throttle> | undefined;
 
   constructor(options: WinstonNewrelicLogsTransportOptions) {
     super();
 
+    this.logs = [];
     this.axiosClient = axios.create({
       timeout: 5000,
       ...options.axiosOptions,
       baseURL: options.apiUrl,
       headers: {
         ...options.axiosOptions?.headers,
-        "X-License-Key": options.licenseKey,
+        "Api-Key": options.licenseKey,
         "Content-Type": "application/json",
       },
     });
+
+    if (
+      options.batchSize !== undefined ||
+      options.batchThrottle !== undefined
+    ) {
+      this.batchSize =
+        options.batchSize === true
+          ? defaultBatchSize
+          : options.batchSize ?? defaultBatchSize;
+      this.batchThrottle =
+        options.batchThrottle === true
+          ? defaultBatchThrottle
+          : options.batchThrottle ?? defaultBatchThrottle;
+
+      if (this.batchSize <= 0) {
+        throw new Error("Expected a batchSize greater than 0");
+      }
+      if (this.batchThrottle <= 0) {
+        throw new Error("Expected a batchThrottle greater than 0");
+      }
+
+      this.throttledBatchPost = throttle(
+        this.batchPost.bind(this),
+        this.batchThrottle,
+        { leading: false, trailing: true }
+      );
+    }
   }
 
-  log(info: { [x in symbol]: string }, callback: (error?: Error) => void) {
+  private batchPost() {
+    try {
+      const toSend = this.logs.slice();
+      this.logs = [];
+
+      this.axiosClient
+        .post("/log/v1", {
+          logs: toSend,
+        })
+        .then(() => {
+          for (const log of toSend) {
+            this.emit("logged", log);
+          }
+        })
+        .catch((err) => {
+          this.emit("error", err);
+        });
+    } catch (err) {
+      this.emit("error", err);
+    }
+  }
+
+  public log(
+    info: { [x in symbol]: string },
+    callback: (error?: Error | null) => void
+  ) {
     // The implementation of log callbacks isn't documented and the exported type
     // definitions appear to be wrong too. This implementation has been compied
     // https://github.com/winstonjs/winston-mongodb/blob/master/lib/winston-mongodb.js#L229-L235
-    // However I don't know what the second argument for callback is supposed to 
+    // However I don't know what the second argument for callback is supposed to
     // indicate.
 
-    this.axiosClient
-      .post("/log/v1", {
-        timestamp: Date.now(),
-        message: info[MESSAGE],
-        logtype: info[LEVEL],
-      })
-      .then(() => {
-        this.emit("logged", info);
-        callback(null);
-      })
-      .catch((err) => {
-        this.emit("error", err);
-        callback(err);
-      });
+    const entry: LogEntry = {
+      timestamp: Date.now(),
+      message: info[MESSAGE],
+      logtype: info[LEVEL],
+    };
+
+    if (this.throttledBatchPost) {
+      this.logs.push(entry);
+      this.throttledBatchPost();
+
+      if (this.logs.length >= this.batchSize) {
+        this.throttledBatchPost.flush();
+      }
+
+      callback(null);
+    } else {
+      this.axiosClient
+        .post("/log/v1", entry)
+        .then(() => {
+          this.emit("logged", entry);
+          callback(null);
+        })
+        .catch((err) => {
+          this.emit("error", err);
+          callback(err);
+        });
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,10 +15,12 @@
   },
   "dependencies": {
     "axios": "^0.21.1",
+    "lodash.throttle": "^4.1.1",
     "logform": "^2.5.1",
     "winston-transport": "^4.2.0"
   },
   "devDependencies": {
+    "@types/lodash.throttle": "^4.1.7",
     "@types/triple-beam": "^1.3.2",
     "tslint": "^6.1.3",
     "typescript": "^4.9.5",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "type": "commonjs",
   "private": false,
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --project tsconfig.build.json",
     "prepublish": "tsc",
     "test": "vitest"
   },

--- a/package.json
+++ b/package.json
@@ -15,11 +15,13 @@
   },
   "dependencies": {
     "axios": "^0.21.1",
+    "lodash.clonedeep": "^4.5.0",
     "lodash.throttle": "^4.1.1",
     "logform": "^2.5.1",
     "winston-transport": "^4.2.0"
   },
   "devDependencies": {
+    "@types/lodash.clonedeep": "^4.5.7",
     "@types/lodash.throttle": "^4.1.7",
     "@types/triple-beam": "^1.3.2",
     "tslint": "^6.1.3",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
     "extends": "./tsconfig.json",
-    "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+    "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "**/*.test.ts"]
   }
   

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,11 @@
 {
-    "extends": "./tsconfig.json",
-    "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "**/*.test.ts"]
-  }
-  
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "node_modules",
+    "test",
+    "dist",
+    "**/*spec.ts",
+    "**/*.test.ts",
+    "vitest.config.ts"
+  ]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
     clearMocks: true,
     exclude: [
       // Comment if you want to run the integration tests.
-      '**/*.integration.test.*'
+      '**/*.integration.test.*',
+      'dist/**/*'
     ]
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     clearMocks: true,
     exclude: [
       // Comment if you want to run the integration tests.
-      'index.integration.test.ts'
+      '**/*.integration.test.*'
     ]
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,5 +6,9 @@ export default defineConfig({
       printBasicPrototype: false,
     },
     clearMocks: true,
+    exclude: [
+      // Comment if you want to run the integration tests.
+      'index.integration.test.ts'
+    ]
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -150,6 +150,18 @@
   resolved "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz"
   integrity sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==
 
+"@types/lodash.throttle@^4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@types/lodash.throttle/-/lodash.throttle-4.1.7.tgz#4ef379eb4f778068022310ef166625f420b6ba58"
+  integrity sha512-znwGDpjCHQ4FpLLx19w4OXDqq8+OvREa05H89obtSyXyOFKL3dDjCslsmfBz0T2FU8dmf5Wx1QvogbINiGIu9g==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.191"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.191.tgz#09511e7f7cba275acd8b419ddac8da9a6a79e2fa"
+  integrity sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==
+
 "@types/node@*":
   version "18.15.0"
   resolved "https://registry.npmjs.org/@types/node/-/node-18.15.0.tgz"
@@ -522,6 +534,11 @@ local-pkg@^0.4.2:
   version "0.4.3"
   resolved "https://registry.npmjs.org/local-pkg/-/local-pkg-0.4.3.tgz"
   integrity sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==
+
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+  integrity sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==
 
 logform@^2.5.1:
   version "2.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -150,6 +150,13 @@
   resolved "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz"
   integrity sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==
 
+"@types/lodash.clonedeep@^4.5.7":
+  version "4.5.7"
+  resolved "https://registry.yarnpkg.com/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.7.tgz#0e119f582ed6f9e6b373c04a644651763214f197"
+  integrity sha512-ccNqkPptFIXrpVqUECi60/DFxjNKsfoQxSQsgcBJCX/fuX1wgyQieojkcWH/KpE3xzLoWN/2k+ZeGqIN3paSvw==
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash.throttle@^4.1.7":
   version "4.1.7"
   resolved "https://registry.yarnpkg.com/@types/lodash.throttle/-/lodash.throttle-4.1.7.tgz#4ef379eb4f778068022310ef166625f420b6ba58"
@@ -534,6 +541,11 @@ local-pkg@^0.4.2:
   version "0.4.3"
   resolved "https://registry.npmjs.org/local-pkg/-/local-pkg-0.4.3.tgz"
   integrity sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==
+
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
 
 lodash.throttle@^4.1.1:
   version "4.1.1"


### PR DESCRIPTION
Currently log requests are sent individually. For high volume applications such as ours this results in significant amount request volume, this implements log batching to bundle together a bunch of log entries into a single POST. Also includes the fix for #16 & #17.

I've validated logging works correctly against our private NewRelic instance with the reworked pattern.
![image](https://user-images.githubusercontent.com/1090602/227163051-5e2e1696-31dd-446e-82b0-c7993c510aff.png)
