### PR TITLE
support for log level

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3,7 +3,7 @@ import TransportStream from "winston-transport";
 import throttle from "lodash.throttle";
 import cloneDeep from "lodash.clonedeep";
 
-export interface WinstonNewrelicLogsTransportOptions {
+export interface WinstonNewrelicLogsTransportOptions extends TransportStream.TransportStreamOptions {
   /**
    * Your NewRelic key.
    *
@@ -54,7 +54,7 @@ export default class WinstonNewrelicLogsTransport extends TransportStream {
    * @param options - Options.
    */
   constructor(options: WinstonNewrelicLogsTransportOptions) {
-    super();
+    super(options);
 
     this.logs = [];
     this.axiosClient = axios.create({


### PR DESCRIPTION
This allows to specify the specific log level for the new relic transport.

```
import { createLogger } from 'winston';
import WinstonNewrelicLogsTransport from 'winston-newrelic-logs-transport';
const logger = createLogger({
    transports: [
        new WinstonNewrelicLogsTransport({
            licenseKey: process.env.NEW_RELIC_LICENSE_KEY,
            apiUrl: process.env.NEW_RELIC_API_URL,
            level: 'error'
        }),
        new winston.transports.Console({
    	    level: 'info'
        }),
    ],
});
```